### PR TITLE
Fixes system header inclusion and a missing return

### DIFF
--- a/example/device_interface/device_interface.c
+++ b/example/device_interface/device_interface.c
@@ -34,7 +34,7 @@ void di_gpio_astronode_write_reset_pin(bool state)
 
 bool di_gpio_astronode_read_event_pin(void)
 {
-
+    return false;
 }
 
 void di_gpio_register_event_pin_it_callback(void (*function_pointer)(void))

--- a/example/device_interface/device_interface.h
+++ b/example/device_interface/device_interface.h
@@ -1,5 +1,5 @@
-#include "stdint.h"
-#include "stdbool.h"
+﻿#include <stdint.h>
+#include <stdbool.h>
 
 typedef enum return_status_t
 {


### PR DESCRIPTION
Fixes syntax of system header inclusion in `device_interface.h`.
Adds a return to example `di_gpio_astronode_read_event_pin` function.